### PR TITLE
Chromium for arm64

### DIFF
--- a/_/amazon/template.yml
+++ b/_/amazon/template.yml
@@ -9,11 +9,13 @@ Resources:
   layer:
     Type: AWS::Serverless::LayerVersion
     Properties:
-        LayerName: sparticuz-chrome-aws-lambda
-        ContentUri: code/
-        CompatibleRuntimes:
-          - nodejs14.x
-          - nodejs16.x
+      LayerName: schrome_arm
+      ContentUri: code/
+      CompatibleArchitectures:
+        - arm64
+      CompatibleRuntimes:
+        - nodejs14.x
+        - nodejs16.x
 
   node14:
     Type: AWS::Serverless::Function
@@ -22,6 +24,8 @@ Resources:
         - !Ref layer
       Handler: handlers/index.handler
       Runtime: nodejs14.x
+      Architectures:
+        - arm64
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXRayDaemonWriteAccess
@@ -33,6 +37,8 @@ Resources:
         - !Ref layer
       Handler: handlers/index.handler
       Runtime: nodejs16.x
+      Architectures:
+        - arm64
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXRayDaemonWriteAccess

--- a/_/ansible/plays/.gclient
+++ b/_/ansible/plays/.gclient
@@ -9,3 +9,4 @@ solutions = [
     },
   },
 ]
+target_cpu = ["arm64","x64"]

--- a/_/ansible/plays/chromium.yml
+++ b/_/ansible/plays/chromium.yml
@@ -293,11 +293,11 @@
           is_official_build = true
           proprietary_codecs = true
           symbol_level = 0
-          target_cpu = "x64"
+          target_cpu = "arm64"
           target_os = "linux"
           use_sysroot = true
           v8_symbol_level = 0
-          v8_target_cpu = "x64"
+          v8_target_cpu = "arm64"
         dest: /srv/source/chromium/src/out/Headless/args.gn
 
     - name: Generating Headless Chromium Configuration
@@ -320,9 +320,15 @@
         warn: false
       register: version
 
-    - name: Striping Symbols from Chromium Binary
+#    - name: Striping Symbols from Chromium Binary
+#      shell: |
+#        strip -o /srv/build/chromium/chromium-{{ version.stdout | quote }} out/Headless/headless_shell
+#      args:
+#        chdir: /srv/source/chromium/src
+
+    - name: Copy Chromium
       shell: |
-        strip -o /srv/build/chromium/chromium-{{ version.stdout | quote }} out/Headless/headless_shell
+        cp out/Headless/headless_shell /srv/build/chromium/chromium-{{ version.stdout | quote }}
       args:
         chdir: /srv/source/chromium/src
 


### PR DESCRIPTION
This PR is for adding arm64 support.

Currently, we seem unable to move forward. Lambda currently runs on Amazon Linux 2, which supports glibc 2.26, but Chromium seems to require glibc 2.29.

```
Failed to launch the browser process!
/tmp/chromium: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /tmp/chromium)
/tmp/chromium: /lib64/libm.so.6: version `GLIBC_2.29' not found (required by /tmp/chromium)


TROUBLESHOOTING: https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md
```

Amazon Linux 2022 supports the higher glibc, however it's also not working when running on Lambda (because Lambda runs on AL2).
```
Failed to launch the browser process!
/tmp/chromium: relocation error: /tmp/aws/lib/libc.so.6: symbol _dl_exception_create, version GLIBC_PRIVATE not defined in file ld-linux-aarch64.so.1 with link time reference


TROUBLESHOOTING: https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md
```

I'm putting this PR up to see if anyone knows what we can do to move forward.