### PR TITLE
Add workaround to define __dirname when running via ESM

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -3,9 +3,14 @@
 import { access, createWriteStream, existsSync, mkdirSync, readdirSync, symlink, unlinkSync } from 'fs';
 import { IncomingMessage } from 'http';
 import LambdaFS from 'lambdafs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { PuppeteerNode, Viewport } from 'puppeteer-core';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
+
+if(typeof __filename === 'undefined') {
+    globalThis.__filename = fileURLToPath(import.meta.url);
+    globalThis.__dirname = dirname(globalThis.__filename);
+}
 
 if (/^AWS_Lambda_nodejs(?:10|12|14)[.]x$/.test(process.env.AWS_EXECUTION_ENV) === true) {
   if (process.env.FONTCONFIG_PATH === undefined) {


### PR DESCRIPTION
When trying to use chrome-aws-lambda via serverless sst the default mode for compiling the files is to output them to ES modules. There's a reference to __dirname in the code that fails as it isn't defined when code runs as an ES module. This is just a change to polyfill __filename and __dirname if they don't exist.

I can't run this locally at the moment as I have an M1 mac. If you have any pointers on how to run chrome-aws-lambda locally on an M1 mac I can do some testing to verify the changes but am currently unable to do so.