### PR TITLE
Add workaround to define __dirname when running via ESM

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -3,9 +3,14 @@
 import { access, createWriteStream, existsSync, mkdirSync, readdirSync, symlink, unlinkSync } from 'fs';
 import { IncomingMessage } from 'http';
 import LambdaFS from './lambdafs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { PuppeteerNode, Viewport } from 'puppeteer-core';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
+
+if(typeof __filename === 'undefined') {
+    globalThis.__filename = fileURLToPath(import.meta.url);
+    globalThis.__dirname = dirname(globalThis.__filename);
+}
 
 if (/^AWS_Lambda_nodejs(?:10|12|14|16)[.]x$/.test(process.env.AWS_EXECUTION_ENV) === true) {
   if (process.env.FONTCONFIG_PATH === undefined) {

--- a/source/index.ts
+++ b/source/index.ts
@@ -8,6 +8,7 @@ import { PuppeteerNode, Viewport } from 'puppeteer-core';
 import { fileURLToPath, URL } from 'url';
 
 if(typeof __filename === 'undefined') {
+    // @ts-expect-error typescript can't handle that this code might be run as a module as well as common js
     globalThis.__filename = fileURLToPath(import.meta.url);
     globalThis.__dirname = dirname(globalThis.__filename);
 }


### PR DESCRIPTION
When the file is imported via an ES Module rather than via commonjs the __dirname global variable does not exist. This is a quick polyfill to add it in when it is not present to try and get it working via ESM as well as commonjs

Currently can't test it works fully as running on an M1 mac so can't run the x86_64 chromium. If you can advise on how to test locally on ARM I'll be able to verify correctly